### PR TITLE
[feat/#31]: 기록 조회/상세조회/등록 구현

### DIFF
--- a/src/main/java/org/crews/controller/FeedController.java
+++ b/src/main/java/org/crews/controller/FeedController.java
@@ -1,0 +1,30 @@
+package org.crews.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.crews.dto.response.FeedSliceResponse;
+import org.crews.service.FeedService;
+import org.crews.utils.AuthUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@Slf4j
+@RestController
+@RequestMapping("/agits/{agits-id}/feeds")
+public class FeedController {
+
+    private final FeedService feedService;
+    private final AuthUtil authUtil;
+
+    @GetMapping
+    public ResponseEntity<FeedSliceResponse> getAllFeeds(
+            @PathVariable("agits-id") Long agitId,
+            @RequestParam int page,
+            HttpServletRequest request) {
+        Long memberId = authUtil.getMemberId(request);
+        System.out.println("memberId = " + memberId);
+        return ResponseEntity.ok().body(feedService.getAllFeeds(memberId, agitId, page));
+    }
+}

--- a/src/main/java/org/crews/controller/FeedController.java
+++ b/src/main/java/org/crews/controller/FeedController.java
@@ -3,6 +3,8 @@ package org.crews.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.crews.dto.request.FeedRequest;
+import org.crews.dto.response.FeedResponse;
 import org.crews.dto.response.FeedSliceResponse;
 import org.crews.service.FeedService;
 import org.crews.utils.AuthUtil;
@@ -24,7 +26,26 @@ public class FeedController {
             @RequestParam int page,
             HttpServletRequest request) {
         Long memberId = authUtil.getMemberId(request);
-        System.out.println("memberId = " + memberId);
+
         return ResponseEntity.ok().body(feedService.getAllFeeds(memberId, agitId, page));
+    }
+
+    @GetMapping("/{feed-id}")
+    public ResponseEntity<FeedResponse> getFeed(
+            @PathVariable("agits-id") Long agitId,
+            @PathVariable("feed-id") Long feedId,
+            HttpServletRequest request){
+        Long memberId = authUtil.getMemberId(request);
+        return ResponseEntity.ok().body(feedService.getFeed(memberId, agitId, feedId));
+    }
+
+    @PostMapping
+    public ResponseEntity<FeedResponse> createFeed(
+            @PathVariable("agits-id") Long agitId,
+            @RequestBody FeedRequest feedRequest,
+            HttpServletRequest request){
+        Long memberId = authUtil.getMemberId(request);
+
+        return ResponseEntity.ok().body(feedService.postFeed(memberId, agitId, feedRequest));
     }
 }

--- a/src/main/java/org/crews/dto/request/FeedRequest.java
+++ b/src/main/java/org/crews/dto/request/FeedRequest.java
@@ -1,0 +1,16 @@
+package org.crews.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FeedRequest {
+    private String image;
+    private String content;
+    private Long likeCount;
+}

--- a/src/main/java/org/crews/dto/request/FeedRequest.java
+++ b/src/main/java/org/crews/dto/request/FeedRequest.java
@@ -1,5 +1,6 @@
 package org.crews.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class FeedRequest {
     private String image;
+
+    @NotBlank(message = "기록 내용은 필수 입력 항목입니다.")
     private String content;
-    private Long likeCount;
 }

--- a/src/main/java/org/crews/dto/response/AgitVaildationResponse.java
+++ b/src/main/java/org/crews/dto/response/AgitVaildationResponse.java
@@ -1,0 +1,15 @@
+package org.crews.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.crews.model.Agit;
+import org.crews.model.Member;
+import org.crews.model.Membership;
+
+@Getter
+@AllArgsConstructor
+public class AgitVaildationResponse {
+    private final Agit agit;
+    private final Member member;
+    private final Membership membership;
+}

--- a/src/main/java/org/crews/dto/response/FeedResponse.java
+++ b/src/main/java/org/crews/dto/response/FeedResponse.java
@@ -6,11 +6,14 @@ import lombok.ToString;
 import org.crews.model.Feed;
 import org.crews.model.Member;
 
+import java.time.LocalDateTime;
+
 @Getter
 @ToString
 @AllArgsConstructor
 public class FeedResponse {
     private Long id;
+    private LocalDateTime createdAt;
     private String image;
     private String content;
     private Long likeCount;
@@ -21,6 +24,7 @@ public class FeedResponse {
                 .anyMatch(heart -> heart.getMember().equals(member));
         return new FeedResponse(
                 feed.getId(),
+                feed.getCreatedAt(),
                 feed.getImage(),
                 feed.getContent(),
                 feed.getLikeCount(),

--- a/src/main/java/org/crews/dto/response/FeedResponse.java
+++ b/src/main/java/org/crews/dto/response/FeedResponse.java
@@ -1,0 +1,30 @@
+package org.crews.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import org.crews.model.Feed;
+import org.crews.model.Member;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class FeedResponse {
+    private Long id;
+    private String image;
+    private String content;
+    private Long likeCount;
+    private boolean likeFeed;
+
+    public static FeedResponse of(Member member, Feed feed) {
+        boolean likeFeed = feed.getLikes().stream()
+                .anyMatch(heart -> heart.getMember().equals(member));
+        return new FeedResponse(
+                feed.getId(),
+                feed.getImage(),
+                feed.getContent(),
+                feed.getLikeCount(),
+                likeFeed
+        );
+    }
+}

--- a/src/main/java/org/crews/dto/response/FeedSliceResponse.java
+++ b/src/main/java/org/crews/dto/response/FeedSliceResponse.java
@@ -1,0 +1,26 @@
+package org.crews.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.crews.model.Feed;
+import org.crews.model.Member;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+public class FeedSliceResponse {
+    private boolean hasNext;
+    private List<FeedResponse> data;
+
+    public static FeedSliceResponse of(Member member, Slice<Feed> feeds) {
+        boolean hasNext = feeds.hasNext();
+        List<FeedResponse> feedResponse = feeds.getContent().stream()
+                .map(feed -> FeedResponse.of(member, feed))
+                .collect(Collectors.toList());
+
+        return new FeedSliceResponse(hasNext, feedResponse);
+    }
+}

--- a/src/main/java/org/crews/exception/ErrorCode.java
+++ b/src/main/java/org/crews/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("이 이메일로 사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     SUBJECT_NOT_FOUND("주제를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     EVENT_NOT_FOUND("해당하는 번호의 정기모임이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+    FEED_NOT_FOUND("해당하는 번호의 기록이 존재하지 않습니다.", HttpStatus.NOT_FOUND),
 
     // 400 BAD_REQUEST
     AUTHORIZED_ACCOUNT_CREATION("통장을 생성할 권한이 없습니다.", HttpStatus.BAD_REQUEST),
@@ -31,6 +32,7 @@ public enum ErrorCode {
     CI_CODE_SEND_ERROR("CI 코드 전송 오류. 다시 회원가입을 진행 해 주세요.", HttpStatus.BAD_REQUEST),
     AUTHORIZED_MEETING_CREATION("모임을 생성할 권한이 없습니다.", HttpStatus.BAD_REQUEST),
     DELETED_MEETING("이미 삭제된 정기모임 입니다.", HttpStatus.BAD_REQUEST),
+    DELETED_FEED("이미 삭제된 기록 입니다.", HttpStatus.BAD_REQUEST),
 
 
     // 403 FORBIDDEN

--- a/src/main/java/org/crews/model/Feed.java
+++ b/src/main/java/org/crews/model/Feed.java
@@ -25,7 +25,7 @@ public class Feed extends BaseTimeEntity{
     private String content;
 
     @ColumnDefault("0")
-    private String likeCount;
+    private Long likeCount;
 
     @Column(columnDefinition = "boolean default false")
     private boolean isDeleted;

--- a/src/main/java/org/crews/model/Feed.java
+++ b/src/main/java/org/crews/model/Feed.java
@@ -2,6 +2,7 @@ package org.crews.model;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.crews.dto.request.FeedRequest;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.util.ArrayList;
@@ -39,4 +40,14 @@ public class Feed extends BaseTimeEntity{
     @OneToMany(mappedBy = "feed")
     @Builder.Default
     private List<Heart> likes = new ArrayList<>();
+
+    public static Feed of(FeedRequest feedRequest, Agit agit, Member member) {
+        return Feed.builder()
+                .image(feedRequest.getImage())
+                .content(feedRequest.getContent())
+                .likeCount(feedRequest.getLikeCount())
+                .agit(agit)
+                .member(member)
+                .build();
+    }
 }

--- a/src/main/java/org/crews/model/Feed.java
+++ b/src/main/java/org/crews/model/Feed.java
@@ -45,7 +45,7 @@ public class Feed extends BaseTimeEntity{
         return Feed.builder()
                 .image(feedRequest.getImage())
                 .content(feedRequest.getContent())
-                .likeCount(feedRequest.getLikeCount())
+                .likeCount(0L)
                 .agit(agit)
                 .member(member)
                 .build();

--- a/src/main/java/org/crews/repository/FeedRepository.java
+++ b/src/main/java/org/crews/repository/FeedRepository.java
@@ -1,0 +1,12 @@
+package org.crews.repository;
+
+import org.crews.model.Feed;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+    Slice<Feed> findByAgitIdAndIsDeletedFalse(Long agitId, Pageable pageable);
+}

--- a/src/main/java/org/crews/service/FeedService.java
+++ b/src/main/java/org/crews/service/FeedService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.crews.dto.request.FeedRequest;
+import org.crews.dto.response.AgitVaildationResponse;
 import org.crews.dto.response.FeedResponse;
 import org.crews.dto.response.FeedSliceResponse;
 import org.crews.exception.CustomException;
@@ -16,6 +17,7 @@ import org.crews.repository.AgitRepository;
 import org.crews.repository.FeedRepository;
 import org.crews.repository.MemberRepository;
 import org.crews.repository.MemberShipRepository;
+import org.crews.utils.CheckExceptionUtil;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -26,48 +28,30 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class FeedService {
     private final FeedRepository feedRepository;
-    private final AgitRepository agitRepository;
-    private final MemberRepository memberRepository;
-    private final MemberShipRepository memberShipRepository;
+    private final CheckExceptionUtil checkExceptionUtil;
 
     public FeedSliceResponse getAllFeeds(Long memberId, Long agitId, int page) {
-        Agit agit = agitRepository.findById(agitId).orElseThrow(
-                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+        AgitVaildationResponse checkedResult = checkExceptionUtil.checkAgitException(memberId, agitId);
 
         Slice<Feed> feeds = feedRepository.findByAgitIdAndIsDeletedFalse(agitId, PageRequest.of(page, 10, Sort.by(Sort.Order.desc("createdAt"))));
-        return FeedSliceResponse.of(member, feeds);
+        return FeedSliceResponse.of(checkedResult.getMember(), feeds);
     }
 
     public FeedResponse getFeed(Long memberId, Long agitId, Long feedId) {
-        Agit agit = agitRepository.findById(agitId).orElseThrow(
-                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+        AgitVaildationResponse checkedResult = checkExceptionUtil.checkAgitException(memberId, agitId);
 
         Feed feed = feedRepository.findById(feedId).orElseThrow(
                 () -> new CustomException(ErrorCode.FEED_NOT_FOUND));
-
         if(feed.isDeleted()) throw new CustomException(ErrorCode.DELETED_FEED);
 
-        return FeedResponse.of(member, feed);
+        return FeedResponse.of(checkedResult.getMember(), feed);
     }
 
     @Transactional
     public FeedResponse postFeed(Long memberId, Long agitId, FeedRequest feedRequest) {
-        Agit agit = agitRepository.findById(agitId).orElseThrow(
-                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+        AgitVaildationResponse checkedResult = checkExceptionUtil.checkAgitException(memberId, agitId);
 
-        Feed feed = Feed.of(feedRequest, agit, member);
-        return FeedResponse.of(member, feedRepository.save(feed));
+        Feed feed = Feed.of(feedRequest, checkedResult.getAgit(), checkedResult.getMember());
+        return FeedResponse.of(checkedResult.getMember(), feedRepository.save(feed));
     }
 }

--- a/src/main/java/org/crews/service/FeedService.java
+++ b/src/main/java/org/crews/service/FeedService.java
@@ -1,0 +1,41 @@
+package org.crews.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.crews.dto.response.FeedSliceResponse;
+import org.crews.exception.CustomException;
+import org.crews.exception.ErrorCode;
+import org.crews.model.Agit;
+import org.crews.model.Feed;
+import org.crews.model.Member;
+import org.crews.model.Membership;
+import org.crews.repository.AgitRepository;
+import org.crews.repository.FeedRepository;
+import org.crews.repository.MemberRepository;
+import org.crews.repository.MemberShipRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class FeedService {
+    private final FeedRepository feedRepository;
+    private final AgitRepository agitRepository;
+    private final MemberRepository memberRepository;
+    private final MemberShipRepository memberShipRepository;
+
+    public FeedSliceResponse getAllFeeds(Long memberId, Long agitId, int page) {
+        Agit agit = agitRepository.findById(agitId).orElseThrow(
+                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
+                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+
+        Slice<Feed> feeds = feedRepository.findByAgitIdAndIsDeletedFalse(agitId, PageRequest.of(page, 10, Sort.by(Sort.Order.desc("createdAt"))));
+        return FeedSliceResponse.of(member, feeds);
+    }
+}

--- a/src/main/java/org/crews/service/FeedService.java
+++ b/src/main/java/org/crews/service/FeedService.java
@@ -1,7 +1,10 @@
 package org.crews.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.crews.dto.request.FeedRequest;
+import org.crews.dto.response.FeedResponse;
 import org.crews.dto.response.FeedSliceResponse;
 import org.crews.exception.CustomException;
 import org.crews.exception.ErrorCode;
@@ -37,5 +40,34 @@ public class FeedService {
 
         Slice<Feed> feeds = feedRepository.findByAgitIdAndIsDeletedFalse(agitId, PageRequest.of(page, 10, Sort.by(Sort.Order.desc("createdAt"))));
         return FeedSliceResponse.of(member, feeds);
+    }
+
+    public FeedResponse getFeed(Long memberId, Long agitId, Long feedId) {
+        Agit agit = agitRepository.findById(agitId).orElseThrow(
+                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
+                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+
+        Feed feed = feedRepository.findById(feedId).orElseThrow(
+                () -> new CustomException(ErrorCode.FEED_NOT_FOUND));
+
+        if(feed.isDeleted()) throw new CustomException(ErrorCode.DELETED_FEED);
+
+        return FeedResponse.of(member, feed);
+    }
+
+    @Transactional
+    public FeedResponse postFeed(Long memberId, Long agitId, FeedRequest feedRequest) {
+        Agit agit = agitRepository.findById(agitId).orElseThrow(
+                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                ()-> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
+                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+
+        Feed feed = Feed.of(feedRequest, agit, member);
+        return FeedResponse.of(member, feedRepository.save(feed));
     }
 }

--- a/src/main/java/org/crews/service/MeetingService.java
+++ b/src/main/java/org/crews/service/MeetingService.java
@@ -3,6 +3,7 @@ package org.crews.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.crews.dto.request.MeetingRequest;
+import org.crews.dto.response.AgitVaildationResponse;
 import org.crews.dto.response.MeetingResponse;
 import org.crews.dto.response.MeetingSliceResponse;
 import org.crews.exception.CustomException;
@@ -16,6 +17,7 @@ import org.crews.repository.AgitRepository;
 import org.crews.repository.MeetingRepository;
 import org.crews.repository.MemberRepository;
 import org.crews.repository.MemberShipRepository;
+import org.crews.utils.CheckExceptionUtil;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
@@ -28,33 +30,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class MeetingService {
 
     private final MeetingRepository meetingRepository;
-    private final AgitRepository agitRepository;
-    private final MemberRepository memberRepository;
-    private final MemberShipRepository memberShipRepository;
+    private final CheckExceptionUtil checkExceptionUtil;
 
     public MeetingSliceResponse getAllEvents(Long memberId, Long agitId, int page) {
-        Agit agit = agitRepository.findById(agitId).orElseThrow(
-                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+        AgitVaildationResponse checkedResult = checkExceptionUtil.checkAgitException(memberId, agitId);
 
         Slice<Meeting> events = meetingRepository.findByAgitIdAndIsDeletedFalse(agitId, PageRequest.of(page, 10, Sort.by(Sort.Order.desc("regularTime"))));
-        return MeetingSliceResponse.of(membership, events);
+        return MeetingSliceResponse.of(checkedResult.getMembership(), events);
     }
 
     public MeetingResponse getEvent(Long memberId, Long agitId, Long meetingId) {
-        Agit agit = agitRepository.findById(agitId).orElseThrow(
-                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+        AgitVaildationResponse checkedResult = checkExceptionUtil.checkAgitException(memberId, agitId);
 
         Meeting meeting = meetingRepository.findById(meetingId).orElseThrow(
                 () -> new CustomException(ErrorCode.EVENT_NOT_FOUND));
-
         if(meeting.isDeleted()) throw new CustomException(ErrorCode.DELETED_MEETING);
 
         return MeetingResponse.from(meeting);
@@ -62,18 +51,13 @@ public class MeetingService {
 
     @Transactional
     public MeetingResponse postEvent(Long memberId, Long agitId, MeetingRequest meetingRequest) {
-        Agit agit = agitRepository.findById(agitId).orElseThrow(
-                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
-        Member member = memberRepository.findById(memberId).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
-                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+        AgitVaildationResponse checkedResult = checkExceptionUtil.checkAgitException(memberId, agitId);
 
-        if(!membership.getRole().equals(MemberRole.LEADER)){
+        if(!checkedResult.getMembership().getRole().equals(MemberRole.LEADER)){
             throw new CustomException(ErrorCode.AUTHORIZED_MEETING_CREATION);
         }
 
-        Meeting meeting = Meeting.of(meetingRequest, agit);
+        Meeting meeting = Meeting.of(meetingRequest, checkedResult.getAgit());
         return MeetingResponse.from(meetingRepository.save(meeting));
     }
 }

--- a/src/main/java/org/crews/utils/CheckExceptionUtil.java
+++ b/src/main/java/org/crews/utils/CheckExceptionUtil.java
@@ -1,0 +1,33 @@
+package org.crews.utils;
+
+import lombok.RequiredArgsConstructor;
+import org.crews.dto.response.AgitVaildationResponse;
+import org.crews.exception.CustomException;
+import org.crews.exception.ErrorCode;
+import org.crews.model.Agit;
+import org.crews.model.Member;
+import org.crews.model.Membership;
+import org.crews.repository.AgitRepository;
+import org.crews.repository.MemberRepository;
+import org.crews.repository.MemberShipRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CheckExceptionUtil {
+
+    private final AgitRepository agitRepository;
+    private final MemberRepository memberRepository;
+    private final MemberShipRepository memberShipRepository;
+
+    public AgitVaildationResponse checkAgitException(Long memberId, Long agitId) {
+        Agit agit = agitRepository.findById(agitId).orElseThrow(
+                () -> new CustomException(ErrorCode.AGIT_NOT_FOUND));
+        Member member = memberRepository.findById(memberId).orElseThrow(
+                () -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Membership membership = memberShipRepository.findByMemberAndAgit(member, agit).orElseThrow(
+                ()-> new CustomException(ErrorCode.MEMBERSHIP_NOT_FOUND));
+
+        return new AgitVaildationResponse(agit, member, membership);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#31 

## 📝작업 내용
- 아지트 기록 전체 조회 구현
- 아지트 기록 상세조회 구현
- 아지트 기록 등록 구현

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
![image](https://github.com/user-attachments/assets/bd6162d0-4805-4eb3-9891-05bf2ea39513)
likeFeed는 해당 기록에 좋아요를 표시했는지 아닌지를 알려주는 boolean 값입니다~
피드백 받아서 생성일자 추가했습니다 