### PR TITLE
60 search agits api

### DIFF
--- a/src/main/java/org/crews/config/SecurityConfig.java
+++ b/src/main/java/org/crews/config/SecurityConfig.java
@@ -90,6 +90,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "/interests").permitAll()
                 .requestMatchers(HttpMethod.GET, "/agits/{agits-id}/introducing").permitAll()
                 .requestMatchers(HttpMethod.GET, "/agits/{agits-id}/meetings/recent").permitAll()
+                .requestMatchers(HttpMethod.GET, "/agits/search").permitAll()
                 .anyRequest().authenticated()
         );
 

--- a/src/main/java/org/crews/controller/AgitController.java
+++ b/src/main/java/org/crews/controller/AgitController.java
@@ -64,8 +64,16 @@ public class AgitController {
     }
 
     @GetMapping("/search")
-    public ResponseEntity<AgitSliceResponse> searchAgits(@RequestParam String keyWord, @PageableDefault(page = 0, size = 5, sort = "id", direction = Sort.Direction.ASC) Pageable pageable){
+    public ResponseEntity<AgitSliceResponse> searchAgits(@RequestParam String keyWord, @PageableDefault(page = 0, size = 5, sort = "id", direction = Sort.Direction.ASC) Pageable pageable, HttpServletRequest request){
+        if(request.getHeader("Authorization") == null) {
+            log.info("여기가 찍히나?");
+            return ResponseEntity.status(HttpStatus.OK).body(agitService.searchAgitAll("%" + keyWord + "%", pageable));
+        }
 
-        return ResponseEntity.status(HttpStatus.OK).body(agitService.searchAgit("%" + keyWord + "%", pageable));
+        Long memberId = authUtil.getMemberId(request);
+        log.info("여기 찍히나?");
+        log.info(String.valueOf(memberId));
+
+        return ResponseEntity.status(HttpStatus.OK).body(agitService.searchAgit("%" + keyWord + "%", memberId, pageable));
     }
 }

--- a/src/main/java/org/crews/controller/AgitController.java
+++ b/src/main/java/org/crews/controller/AgitController.java
@@ -9,9 +9,7 @@ import org.crews.dto.request.AgitRequest;
 import org.crews.model.constants.MemberRole;
 import org.crews.service.AgitService;
 import org.crews.utils.AuthUtil;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -66,13 +64,10 @@ public class AgitController {
     @GetMapping("/search")
     public ResponseEntity<AgitSliceResponse> searchAgits(@RequestParam String keyWord, @PageableDefault(page = 0, size = 5, sort = "id", direction = Sort.Direction.ASC) Pageable pageable, HttpServletRequest request){
         if(request.getHeader("Authorization") == null) {
-            log.info("여기가 찍히나?");
             return ResponseEntity.status(HttpStatus.OK).body(agitService.searchAgitAll("%" + keyWord + "%", pageable));
         }
 
         Long memberId = authUtil.getMemberId(request);
-        log.info("여기 찍히나?");
-        log.info(String.valueOf(memberId));
 
         return ResponseEntity.status(HttpStatus.OK).body(agitService.searchAgit("%" + keyWord + "%", memberId, pageable));
     }

--- a/src/main/java/org/crews/controller/AgitController.java
+++ b/src/main/java/org/crews/controller/AgitController.java
@@ -4,14 +4,17 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.crews.dto.request.AgitRegisterRequest;
-import org.crews.dto.response.AgitRegisterResponse;
-import org.crews.dto.response.AgitResponse;
+import org.crews.dto.response.*;
 import org.crews.dto.request.AgitRequest;
-import org.crews.dto.response.AllAgitsInfoResponse;
-import org.crews.dto.response.DuesAlarmResponse;
 import org.crews.model.constants.MemberRole;
 import org.crews.service.AgitService;
 import org.crews.utils.AuthUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -58,5 +61,11 @@ public class AgitController {
     @PostMapping("/registrations")
     public ResponseEntity<AgitRegisterResponse> registerAgit(@RequestBody AgitRegisterRequest agitRegisterRequest){
         return agitService.agitRestration(agitRegisterRequest);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<AgitSliceResponse> searchAgits(@RequestParam String keyWord, @PageableDefault(page = 0, size = 5, sort = "id", direction = Sort.Direction.ASC) Pageable pageable){
+
+        return ResponseEntity.status(HttpStatus.OK).body(agitService.searchAgit("%" + keyWord + "%", pageable));
     }
 }

--- a/src/main/java/org/crews/dto/response/AgitSliceResponse.java
+++ b/src/main/java/org/crews/dto/response/AgitSliceResponse.java
@@ -1,0 +1,24 @@
+package org.crews.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.crews.model.Agit;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AgitSliceResponse {
+    private boolean hasNext;
+    private List<AgitResponse> data;
+
+    public static AgitSliceResponse of(Slice<Agit> events) {
+        boolean hasNext = events.hasNext();
+        List<AgitResponse> agitResponses = events.getContent().stream()
+                .map(AgitResponse::from)
+                .toList();
+
+        return new AgitSliceResponse(hasNext, agitResponses);
+    }
+}

--- a/src/main/java/org/crews/dto/response/IntroducingResponse.java
+++ b/src/main/java/org/crews/dto/response/IntroducingResponse.java
@@ -3,13 +3,9 @@ package org.crews.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
-import org.crews.model.Interesting;
-import org.crews.model.InterestingAndAgit;
-import org.crews.model.Introducing;
-import org.crews.model.Subject;
+import org.crews.model.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @ToString
@@ -18,6 +14,7 @@ public class IntroducingResponse {
     private String image;
     private String introduce;
     private String content;
+    private AddressResponse address;
     private String subject;
     private List<InterestingResponse> interests;
 
@@ -25,10 +22,13 @@ public class IntroducingResponse {
         List<InterestingResponse> interestingResponse = introducing.getAgit().getInterestingAndAgits().stream()
                 .map(interestingAndAgit -> InterestingResponse.from(interestingAndAgit.getInteresting()))
                 .toList();
+        AddressResponse agitAddress = AddressResponse.from(introducing.getAgit().getAddress());
+
         return new IntroducingResponse(
                 introducing.getImage(),
                 introducing.getIntroduce(),
                 introducing.getContent(),
+                agitAddress,
                 introducing.getAgit().getSubject().getSubjectName(),
                 interestingResponse
         );

--- a/src/main/java/org/crews/jwt/LoginFilter.java
+++ b/src/main/java/org/crews/jwt/LoginFilter.java
@@ -71,7 +71,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
         Long memberId = memberDetails.getMember().getId();
 
-        String access = jwtUtil.createJwt("access", email, role, memberId,600000L);
+        String access = jwtUtil.createJwt("access", email, role, memberId,864000000L);
         String refresh = jwtUtil.createJwt("refresh", email, role, memberId,864000000L);
 
         //Refresh 토큰 저장

--- a/src/main/java/org/crews/repository/AgitRepository.java
+++ b/src/main/java/org/crews/repository/AgitRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -21,4 +22,12 @@ public interface AgitRepository extends JpaRepository<Agit, Long> {
     List<Agit> findAllWithFetchJoin();
 
     Slice<Agit> findByIntroductionLikeAndIsDeletedFalse(String keyWord, Pageable pageable);
+
+    @Query("SELECT a FROM Agit a " +
+            "WHERE a.isDeleted = false " +
+            "AND a.introduction LIKE %:keyword% " +
+            "AND a.id NOT IN (" +
+            "    SELECT m.agit.id FROM Membership m WHERE m.member.id = :memberId" +
+            ")")
+    Slice<Agit> findByKeywordAndNotJoined(@Param("keyword") String keyword, @Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/org/crews/repository/AgitRepository.java
+++ b/src/main/java/org/crews/repository/AgitRepository.java
@@ -1,6 +1,8 @@
 package org.crews.repository;
 
 import org.crews.model.Agit;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -17,4 +19,6 @@ public interface AgitRepository extends JpaRepository<Agit, Long> {
             "JOIN FETCH ia.interesting " +
             "WHERE a.isDeleted = false")
     List<Agit> findAllWithFetchJoin();
+
+    Slice<Agit> findByIntroductionLikeAndIsDeletedFalse(String keyWord, Pageable pageable);
 }

--- a/src/main/java/org/crews/service/AgitService.java
+++ b/src/main/java/org/crews/service/AgitService.java
@@ -5,17 +5,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.crews.dto.request.AgitRegisterRequest;
 import org.crews.dto.request.AgitRequest;
-import org.crews.dto.response.AgitInfoResponse;
-import org.crews.dto.response.AllAgitsInfoResponse;
-import org.crews.dto.response.AgitRegisterResponse;
-import org.crews.dto.response.DuesAlarmResponse;
-import org.crews.dto.response.AgitResponse;
+import org.crews.dto.response.*;
 
 import org.crews.exception.CustomException;
 import org.crews.exception.ErrorCode;
 import org.crews.model.*;
 import org.crews.model.constants.MemberRole;
 import org.crews.repository.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -24,6 +23,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -162,4 +162,9 @@ public class AgitService {
         }
     }
 
+    public AgitSliceResponse searchAgit(String keyWord, Pageable pageable) {
+        Slice<Agit> agitSlice = agitRepository.findByIntroductionLikeAndIsDeletedFalse(keyWord, pageable);
+
+        return AgitSliceResponse.of(agitSlice);
+    }
 }

--- a/src/main/java/org/crews/service/AgitService.java
+++ b/src/main/java/org/crews/service/AgitService.java
@@ -12,7 +12,6 @@ import org.crews.exception.ErrorCode;
 import org.crews.model.*;
 import org.crews.model.constants.MemberRole;
 import org.crews.repository.*;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
@@ -23,7 +22,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -162,7 +160,14 @@ public class AgitService {
         }
     }
 
-    public AgitSliceResponse searchAgit(String keyWord, Pageable pageable) {
+    public AgitSliceResponse searchAgit(String keyWord, Long memberId, Pageable pageable) {
+        Slice<Agit> agitSlice = agitRepository.findByKeywordAndNotJoined(keyWord, memberId, pageable);
+
+
+        return AgitSliceResponse.of(agitSlice);
+    }
+
+    public AgitSliceResponse searchAgitAll(String keyWord, Pageable pageable) {
         Slice<Agit> agitSlice = agitRepository.findByIntroductionLikeAndIsDeletedFalse(keyWord, pageable);
 
         return AgitSliceResponse.of(agitSlice);

--- a/src/main/java/org/crews/service/MemberServiceImpl.java
+++ b/src/main/java/org/crews/service/MemberServiceImpl.java
@@ -157,7 +157,7 @@ public class MemberServiceImpl implements MemberService {
         String role = jwtUtil.getRole(refresh);
         Long memberId = jwtUtil.getMemberId(refresh);
 
-        String newAccessToken = jwtUtil.createJwt(accessTokenName, username, role, memberId, 600000L);
+        String newAccessToken = jwtUtil.createJwt(accessTokenName, username, role, memberId, 864000000L);
         String newRefreshToken = jwtUtil.createJwt(refreshTokenName, username, role, memberId, 86400000L);
 
         //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장


### PR DESCRIPTION
## #️⃣연관된 이슈
> #60 

## 📝작업 내용
> 검색 API에서 검색 시 유저의 로그인 여부를 판별하여 로그인을 한 경우 검색 키워드의 아지트 중 가입하지 않은 아지트 목록을 주고 로그인을 하지 않은 경우 검색 키워드의 모든 아지트 목록을 반환하도록 로직 수정

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)