### PR TITLE
아지트 정모 수정 api 구현

### DIFF
--- a/src/main/java/org/crews/controller/FeedController.java
+++ b/src/main/java/org/crews/controller/FeedController.java
@@ -1,6 +1,7 @@
 package org.crews.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.crews.dto.request.FeedRequest;
@@ -42,7 +43,7 @@ public class FeedController {
     @PostMapping
     public ResponseEntity<FeedResponse> createFeed(
             @PathVariable("agits-id") Long agitId,
-            @RequestBody FeedRequest feedRequest,
+            @RequestBody @Valid FeedRequest feedRequest,
             HttpServletRequest request){
         Long memberId = authUtil.getMemberId(request);
 

--- a/src/main/java/org/crews/controller/MeetingController.java
+++ b/src/main/java/org/crews/controller/MeetingController.java
@@ -1,6 +1,7 @@
 package org.crews.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.crews.dto.request.MeetingRequest;
@@ -55,4 +56,16 @@ public class MeetingController {
 
         return ResponseEntity.ok().body(meetingService.postEvent(memberId, agitId, meetingRequest));
     }
+
+    @PutMapping("/{meeting-id}")
+    public ResponseEntity<MeetingResponse> updateMeeting(
+            @PathVariable("agits-id") Long agitId,
+            @PathVariable("meeting-id") Long meetingId,
+            @RequestBody @Valid  MeetingRequest meetingRequest,
+            HttpServletRequest request
+    ){
+        Long memberId = authUtil.getMemberId(request);
+        return ResponseEntity.ok().body(meetingService.editEvent(memberId, agitId, meetingId, meetingRequest));
+    }
+
 }

--- a/src/main/java/org/crews/dto/request/MeetingRequest.java
+++ b/src/main/java/org/crews/dto/request/MeetingRequest.java
@@ -1,6 +1,9 @@
 package org.crews.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +24,9 @@ public class MeetingRequest {
     @NotBlank(message = "정기모임 위치는 필수 입력 항목입니다.")
     private String place;
 
-    @NotBlank(message = "정기모임 날짜는 필수 입력 항목입니다.")
+    @NotNull(message = "정기모임 날짜는 필수 입력 항목입니다.")
+    @Future(message="현재 시간 이후로 설정해주세요.")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime date;
 
     @NotBlank(message = "정기모임 유의사항은 필수 입력 항목입니다.")

--- a/src/main/java/org/crews/dto/request/MeetingRequest.java
+++ b/src/main/java/org/crews/dto/request/MeetingRequest.java
@@ -25,10 +25,10 @@ public class MeetingRequest {
     private String place;
 
     @NotNull(message = "정기모임 날짜는 필수 입력 항목입니다.")
-    @Future(message="현재 시간 이후로 설정해주세요.")
+    @Future(message="현재 시간 이전은 설정이 불가능합니다.")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime date;
 
-    @NotBlank(message = "정기모임 유의사항은 필수 입력 항목입니다.")
+    @NotBlank(message = "정기모임 안내사항은 필수 입력 항목입니다.")
     private String content;
 }

--- a/src/main/java/org/crews/model/Meeting.java
+++ b/src/main/java/org/crews/model/Meeting.java
@@ -47,4 +47,12 @@ public class Meeting extends BaseTimeEntity{
                 .content(meetingRequest.getContent())
                 .build();
     }
+
+    public void update(MeetingRequest meetingRequest){
+        this.regularName = meetingRequest.getName();
+        this.image=meetingRequest.getImage();
+        this.regularTime=meetingRequest.getDate();
+        this.place=meetingRequest.getPlace();
+        this.content=meetingRequest.getContent();
+    }
 }

--- a/src/main/java/org/crews/service/MeetingService.java
+++ b/src/main/java/org/crews/service/MeetingService.java
@@ -74,7 +74,7 @@ public class MeetingService {
     public MeetingResponse editEvent(Long memberId, Long agitId, Long meetingId, MeetingRequest meetingRequest) {
         AgitVaildationResponse checkedResult = checkExceptionUtil.checkAgitException(memberId, agitId);
         Meeting meeting=meetingRepository.findById(meetingId).orElseThrow(()->new CustomException(ErrorCode.EVENT_NOT_FOUND));
-        if(!checkedResult.getMembership().getRole().equals(MemberRole.LEADER)){
+        if(!checkedResult.getMembership().getAgitRole().equals(AgitRole.LEADER)){
             throw new CustomException(ErrorCode.AUTHORIZED_CAPTAIN_ONLY);
         }
 

--- a/src/main/java/org/crews/service/MeetingService.java
+++ b/src/main/java/org/crews/service/MeetingService.java
@@ -69,4 +69,18 @@ public class MeetingService {
         Meeting meeting = Meeting.of(meetingRequest, checkedResult.getAgit());
         return MeetingResponse.from(meetingRepository.save(meeting));
     }
+
+    @Transactional
+    public MeetingResponse editEvent(Long memberId, Long agitId, Long meetingId, MeetingRequest meetingRequest) {
+        AgitVaildationResponse checkedResult = checkExceptionUtil.checkAgitException(memberId, agitId);
+        Meeting meeting=meetingRepository.findById(meetingId).orElseThrow(()->new CustomException(ErrorCode.EVENT_NOT_FOUND));
+        if(!checkedResult.getMembership().getRole().equals(MemberRole.LEADER)){
+            throw new CustomException(ErrorCode.AUTHORIZED_CAPTAIN_ONLY);
+        }
+
+        meeting.update(meetingRequest);
+        return MeetingResponse.from(meetingRepository.save(meeting));
+
+
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #65 

## 📝작업 내용
> 아지트 정모 상세 수정 api 구현
> localdatetime은 string 처리가 안되어 notblank에서 notnull로 수정 / 현재 시간 이전 시간으로 설정할 수 없도록 수정

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? 등
