### PR TITLE
[feat/#76]: 아지트 관리 api 추가, 암호화 안된 데이터를 복호화할 때 그냥 원래 값 출력하는 메서드 추가(삭제 가능)

### DIFF
--- a/src/main/java/org/crews/controller/AgitController.java
+++ b/src/main/java/org/crews/controller/AgitController.java
@@ -96,7 +96,28 @@ public class AgitController {
         return ResponseEntity.status(HttpStatus.OK).body(agitmanageResponse);
     }
 
-    @PostMapping("/{agits-id}/manage/accounts")
+    @GetMapping("/{agits-id}/manage/details")
+    public ResponseEntity<AgitManageResponse> accountManage(@PathVariable("agits-id") Long agitId, HttpServletRequest request){
+        Long memberId = authUtil.getMemberId(request);
+        AgitRole agitRole = agitService.getAgitRole(agitId, memberId);
+        if(agitRole.equals(AgitRole.TEMP)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(AgitManageResponse.builder().message("접근 권한이 없습니다.").build());
+        }
+        AgitManageResponse agitMemberResponse = agitService.getMembers(agitId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(agitMemberResponse);
+    }
+    @GetMapping("/{agits-id}/manage/approve")
+    public ResponseEntity<AgitManageResponse> memberManage(@PathVariable("agits-id") Long agitId, HttpServletRequest request){
+        Long memberId = authUtil.getMemberId(request);
+        AgitRole agitRole = agitService.getAgitRole(agitId, memberId);
+        if(agitRole.equals(AgitRole.TEMP)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(AgitManageResponse.builder().message("접근 권한이 없습니다.").build());
+        }
+        AgitManageResponse agitTempResponse = agitService.getTemps(agitId);
+        return ResponseEntity.status(HttpStatus.OK).body(agitTempResponse);
+    }
+    @PostMapping("/{agits-id}/manage/details")
     public ResponseEntity<MembershipResponse> accountAuthorization(
             @PathVariable("agits-id") Long agitId, @RequestBody AgitAuthorRequest agitAuthorRequest, HttpServletRequest request
     ){
@@ -105,7 +126,7 @@ public class AgitController {
         return ResponseEntity.ok().body(membershipResponse);
     }
 
-    @PostMapping("/{agits-id}/manage/members")
+    @PostMapping("/{agits-id}/manage/approve")
     public ResponseEntity<MembershipResponse> memberAuthorization(
             @PathVariable("agits-id") Long agitId,
             @RequestBody AgitAuthorRequest agitAuthorRequest, HttpServletRequest request

--- a/src/main/java/org/crews/repository/MembershipRepository.java
+++ b/src/main/java/org/crews/repository/MembershipRepository.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 @Repository
 public interface MembershipRepository extends JpaRepository<Membership, Long> {
     Optional<Membership> findByAgitAndAgitRole(Agit agit, AgitRole role);
-
+    Optional<Membership> findByAgitAndAgitRoleNot(Agit agit, AgitRole role);
     Optional<Membership> findByMemberAndAgit(Member member, Agit agit);
     @EntityGraph(attributePaths = {"member"})
     List<Membership> findByAgit(Agit agit);
@@ -42,6 +42,21 @@ public interface MembershipRepository extends JpaRepository<Membership, Long> {
 
     Long countByAgitAndAgitRoleLike(Agit build, AgitRole agitRole);
 
+    @Query("""
+    SELECT m
+    FROM Membership m
+    LEFT JOIN FETCH m.member
+    WHERE m.agit.id = :agitId AND m.agitRole <> :agitRole
+""")
+    List<Membership> findByAgitIdAndAgitRoleNot(@Param("agitId") Long agitId, @Param("agitRole") AgitRole agitRole);
+
+    @Query("SELECT m FROM Membership m " +
+            "JOIN FETCH m.agit a " +
+            "WHERE a.id = :agitId AND m.agitRole = :agitRole")
+    List<Membership> findByAgitIdAndAgitRole(
+            @Param("agitId") Long agitId,
+            @Param("agitRole") AgitRole agitRole
+    );
 
     @Query("SELECT m FROM Membership m " +
             "JOIN FETCH m.agit a " +

--- a/src/main/java/org/crews/service/AgitService.java
+++ b/src/main/java/org/crews/service/AgitService.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 
 @Slf4j
@@ -207,7 +208,37 @@ public class AgitService {
 
         return AgitSliceResponse.of(agitSlice);
     }
+    public AgitManageResponse getMembers(Long agitId){
+        // TEMP가 아닌 모든 멤버 가져오기
+        List<Membership> membershipList = membershipRepository.findByAgitIdAndAgitRoleNot(agitId, AgitRole.TEMP);
 
+        // DTO로 변환
+        List<AgitManageMemberResponse> memberResponses = membershipList.stream()
+                .map(membership -> AgitManageMemberResponse.from(membership.getMember(), membership.getAgitRole()))
+                .toList();
+
+        return AgitManageResponse.builder()
+                .members(memberResponses)
+                .currentMember((long) membershipList.size()) // 현재 멤버 수
+                .message("Agit Role이 TEMP가 아닌 멤버 리스트입니다.")
+                .build();
+    }
+
+    public AgitManageResponse getTemps(Long agitId){
+        // TEMP 역할의 멤버 가져오기
+        List<Membership> tempMemberships = membershipRepository.findByAgitIdAndAgitRole(agitId, AgitRole.TEMP);
+
+        // DTO로 변환
+        List<AgitManageMemberResponse> memberResponses = tempMemberships.stream()
+                .map(membership -> AgitManageMemberResponse.from(membership.getMember(), membership.getAgitRole()))
+                .collect(Collectors.toList());
+
+        return AgitManageResponse.builder()
+                .members(memberResponses)
+                .currentMember((long) memberResponses.size())
+                .message("TEMP 역할 멤버 리스트입니다.")
+                .build();
+    }
     public AgitManageResponse getAgitMember(Long agitId, AgitRole agitRole) {
         List<Membership> membershipList = membershipRepository.findTop3ByAgitAndAgitRoleNot(Agit.builder().id(agitId).build(), AgitRole.TEMP);
         Long totalMembership = membershipRepository.countByAgitAndAgitRoleNot(Agit.builder().id(agitId).build(), AgitRole.TEMP);

--- a/src/main/java/org/crews/utils/AESUtil.java
+++ b/src/main/java/org/crews/utils/AESUtil.java
@@ -46,6 +46,10 @@ public class AESUtil {
                 throw new AESUtilException("SecretKey 또는 IV가 설정되지 않았습니다.");
             }
 
+            if (!isBase64(encryptedData)) {
+                return encryptedData; // 암호화된 데이터가 아니면 입력값 그대로 반환
+            }
+
             Cipher cipher = Cipher.getInstance(ALGORITHM);
             SecretKeySpec keySpec = new SecretKeySpec(aesConfig.getSecretKey().getBytes(), "AES");
 
@@ -57,6 +61,14 @@ public class AESUtil {
             return new String(cipher.doFinal(decodedBytes));
         } catch (Exception e) {
             throw new AESUtilException("데이터 복호화 중 오류 발생", e);
+        }
+    }
+    private static boolean isBase64(String data) {
+        try {
+            Base64.getDecoder().decode(data);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #76 

## 📝작업 내용
> 아지트 관리 api 추가
> 암호화 안된 데이터를 복호화할 때 그냥 원래 값 출력하는 메서드 추가(삭제 가능)

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? 등
